### PR TITLE
グループの登録・編集機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "haml-rails", ">= 1.0", '<= 2.0.1'
 gem 'font-awesome-sass'
 gem 'devise'
+gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
     bindex (0.8.1)
     builder (3.2.4)
     byebug (11.1.1)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -104,6 +105,11 @@ GEM
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     puma (3.12.2)
     rack (2.2.2)
     rack-test (0.6.3)
@@ -200,6 +206,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-rails
   puma (~> 3.0)
   rails (~> 5.0.7, >= 5.0.7.2)
   sass-rails (~> 5.0)

--- a/app/assets/javascripts/groups.coffee
+++ b/app/assets/javascripts/groups.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,5 +5,6 @@
 @import "modules/messages";
 @import "modules/user";
 @import "modules/flash";
+@import "modules/group";
 
 

--- a/app/assets/stylesheets/modules/group.scss
+++ b/app/assets/stylesheets/modules/group.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the groups controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,37 @@
+class GroupsController < ApplicationController
+  def index
+  end
+
+  def new
+    @group = Group.new
+    @group.users << current_user
+  end
+
+  def create
+    @group = Group.new(group_params)
+    if @group.save
+      redirect_to root_path, notice: 'グループを作成しました'
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @group = Group.find(params[:id])
+  end
+
+  def update
+    @group = Group.find(params[:id])
+    if @group.update(group_params)
+      redirect_to root_path, notice: 'グループを更新しました'
+    else
+      render :edit
+    end
+  end
+
+  private
+  def group_params
+    params.require(:group).permit(:name, user_ids:[])
+    
+  end
+end

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,5 @@
+class Group < ApplicationRecord
+  has_many :group_users
+  has_many :users, through: :group_users
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/group_user.rb
+++ b/app/models/group_user.rb
@@ -1,0 +1,4 @@
+class GroupUser < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
+
+  has_many :group_users
+  has_many :groups, through: :group_users
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,26 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
+  .chat-group-form__field
+    .chat-group-form__field--left
+      =f.label :name, class: 'chat-group-form__label'
+    .chat-group-form__field--right
+      =f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+  .chat-group-form__field.clearfix
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+    .chat-group-form__field--right
+
+      =f.collection_check_boxes :user_ids, User.all, :id, :name
+
+    .chat-group-form__field.clearfix
+      .chat-group-form__field--left
+      .chat-group-form__field--right
+        =f.submit class: 'chat-group-from__action-btn'
+

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,3 @@
+.chat-group-form
+  %h1 チャットグループ編集
+  =render partial: 'form', locals:{group: @group }

--- a/app/views/groups/index.html.haml
+++ b/app/views/groups/index.html.haml
@@ -1,0 +1,2 @@
+.wrapper
+  = render 'messages/side_bar'

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,0 +1,4 @@
+.chat-group-form
+  %h1 新規チャットグループ
+  = render partial: 'form', locals: {group: @group}
+  

--- a/app/views/messages/_side_bar.html.haml
+++ b/app/views/messages/_side_bar.html.haml
@@ -5,13 +5,16 @@
         = current_user.name
       %ul.side--bar__user--name__top--items__icons
         %li.side--bar__user--name__top--items__icons__new
-          = link_to "#" do
+          = link_to new_group_path do
             = icon("far", "edit")
         %li.side--bar__user--name__top--items__icons__setting
           = link_to "users/#{current_user.id}/edit" do
             = icon("fas", "cog")
   .side--bar__group--list
-    .side--bar__group--list__logo
-      techcamp
-    .side--bar__group--list__message
-      まだメッセージがありません
+    - current_user.groups.each do |group|
+      .group
+        = link_to '#' do
+          .side--bar__group--list__logo
+            = group.name
+          .side--bar__group--list__message
+            まだメッセージがありません

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root "messages#index"
+  root "groups#index"
   resources :users, only:[:edit, :update]
-
+  resources :groups, only:[:index, :new, :create, :edit, :update]
 end

--- a/db/migrate/20200229063802_create_groups.rb
+++ b/db/migrate/20200229063802_create_groups.rb
@@ -1,0 +1,9 @@
+class CreateGroups < ActiveRecord::Migration[5.0]
+  def change
+    create_table :groups do |t|
+      t.string :name, null: false
+      t.index :name, unique: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200229063812_create_group_users.rb
+++ b/db/migrate/20200229063812_create_group_users.rb
@@ -1,0 +1,9 @@
+class CreateGroupUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :group_users do |t|
+      t.references :group, foreign_key: true
+      t.references :user, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200228072416) do
+ActiveRecord::Schema.define(version: 20200229063812) do
+
+  create_table "group_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "group_id"
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_group_users_on_group_id", using: :btree
+    t.index ["user_id"], name: "index_group_users_on_user_id", using: :btree
+  end
+
+  create_table "groups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_groups_on_name", unique: true, using: :btree
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",                                null: false
@@ -26,4 +42,6 @@ ActiveRecord::Schema.define(version: 20200228072416) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "group_users", "groups"
+  add_foreign_key "group_users", "users"
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/group_users.yml
+++ b/test/fixtures/group_users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/group_user_test.rb
+++ b/test/models/group_user_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GroupUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
グループの登録機能の実装。
グループの編集機能の実装。
サイドバーにグループ名と新着メッセージの表示部分（今は「まだメッセージがありません」のみ）の実装。
登録・編集時に保存できなければエラーメッセージを表示するよう実装。

# Why 
ユーザーがチャットする際グループ化をするため、グループの登録機能を実装。
グループ名やメンバーの変更ができるよう実装。
視覚的にわかるようトップページのサイドバー部にグループ名と新着メッセージの表示。
エラーがわかるよう表示。