### PR TITLE
[WIP]ヘッダー部にグループ名とメンバー名を実装

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -120,8 +120,7 @@ $form-btn: #38aef0; //editやsendボタンに使う色
       padding-left: 40px;
       &__show{
         &--info{
-          color: #333;
-          font-size: 16px;
+          
         }
         &--comment{
           color: #434a54;
@@ -178,3 +177,31 @@ $form-btn: #38aef0; //editやsendボタンに使う色
 .new_message{
   width: 100%;
 }
+
+.message{
+  margin-bottom: 46px;
+}
+
+.upper-message{
+  display: flex;
+  position: relative;
+  &__user-name{
+    color: #333;
+    font-size: 16px;
+  }
+  &__date{
+    color: #999;
+    font-size: 12px;
+    margin-left: 10px;
+  }
+  .lower-message{
+      color: #434A54;
+      font-size: 14px;
+      position: absolute;
+      top: 28px;
+      left: 0;
+  }
+}
+
+
+

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 class GroupsController < ApplicationController
   def index
+    @group = Group.find(params[:id])
   end
 
   def new
@@ -32,6 +33,6 @@ class GroupsController < ApplicationController
   private
   def group_params
     params.require(:group).permit(:name, user_ids:[])
-    
   end
+
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -16,8 +16,9 @@ class MessagesController < ApplicationController
       flash.now[:alert] = 'メッセージを入力してください'
       render :index
    end
-
   end
+
+  
 
   private
   def message_params

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,9 +2,11 @@
   .chat--main__group--info
     .chat--main__group--info__left
       .chat--main__group--info__left__group--name
-        test
+        = @group.name
       .chat--main__group--info__left--members
-        Member : Kaito
+        Member :
+        - @user.each do |user|
+          = user.name
     .chat--main__group--info__edit
       = link_to "#"  do
         Edit

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,5 +9,6 @@ Bundler.require(*Rails.groups)
 module ChatSpace
   class Application < Rails::Application
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
# What
ヘッダーにグループ名とメンバー名を実装。
コメントが崩れていたので、きれいに実装。また、投稿時間を東京（日本）時間に直した。

# Why
ヘッダーにユーザーが使用しているグループ名が表示されると便利だから。また、メンバーが誰がいるのかわかるように実装。

コメントの内容やユーザー名、投稿時間のバランスが良いと見やすいため。また、日本語話者を想定しているので、時間は日本時間に合わせた方が都合が良いから。